### PR TITLE
Revert "Bump spring-security-bom from 4.2.11.RELEASE to 5.2.10.RELEASE"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
             <dependency>
                 <groupId>org.springframework.security</groupId>
                 <artifactId>spring-security-bom</artifactId>
-                <version>5.2.10.RELEASE</version>
+                <version>4.2.11.RELEASE</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>


### PR DESCRIPTION
Reverts WISVCH/connect#33 because it doesn't work.