### PR TITLE
Increase max login age for saml to fix google login

### DIFF
--- a/src/main/webapp/WEB-INF/wisvch-saml.xml
+++ b/src/main/webapp/WEB-INF/wisvch-saml.xml
@@ -201,7 +201,7 @@
 
     <!-- SAML 2.0 WebSSO Assertion Consumer -->
     <bean id="webSSOprofileConsumer" class="org.springframework.security.saml.websso.WebSSOProfileConsumerImpl">
-        <property name="maxAuthenticationAge" value="28800"/>
+        <property name="maxAuthenticationAge" value="31556926"/> <!-- One year -->
     </bean>
 
     <!-- SAML 2.0 Holder-of-Key WebSSO Assertion Consumer -->


### PR DESCRIPTION
The problem I found with the google login is as follows: When the user is already logged in to google for more then 8 hours, connect will not except the login.

I found this by turning on some more logging locally, and found the error:
`Caused by: org.springframework.security.authentication.CredentialsExpiredException: Authentication statement is too old to be used with value 2024-11-26T18:31:15.000Z` (This was the time I logged in yesterday) Everything was working then, but when I tried today, it was not. This is because google adds the time you signed in in google to the saml response, and spring checks if it is within `maxAuthenticationAge`. There are two solutions: let the user re-sign in on google, or increase this max age.

According to https://stackoverflow.com/questions/75457068/is-there-a-way-in-google-sso-to-force-the-user-to-re-enter-their-google-password the first option doesn't work voor google, so the second option it is.

I hope this fixes it! (I tested it locally and it seems to make the difference)