### PR TITLE
feat: add exception handling for pre-students

### DIFF
--- a/src/main/java/ch/wisv/connect/authentication/CHAuthenticationProvider.java
+++ b/src/main/java/ch/wisv/connect/authentication/CHAuthenticationProvider.java
@@ -19,6 +19,7 @@ package ch.wisv.connect.authentication;
 import ch.wisv.connect.model.CHUserDetails;
 import ch.wisv.connect.services.CHUserDetailsService;
 import ch.wisv.connect.services.CHUserDetailsService.CHInvalidMemberException;
+import ch.wisv.connect.services.CHUserDetailsService.CHPreStudentAuthenticatedException;
 import org.opensaml.saml2.core.Attribute;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -90,7 +91,11 @@ public class CHAuthenticationProvider implements AuthenticationProvider {
                     break;
                 default:
                     log.warn("Unsupported SAML affiliation: affiliation={}", affiliation);
-                    throw new CHInvalidMemberException();
+                    if (affiliation.equals("pre-student")) {
+                        throw new CHPreStudentAuthenticatedException();
+                    } else {
+                        throw new CHInvalidMemberException();
+                    }
             }
 
             return CHAuthenticationToken.createAuthenticationToken(authentication, userDetails);

--- a/src/main/java/ch/wisv/connect/authentication/CHAuthenticationProvider.java
+++ b/src/main/java/ch/wisv/connect/authentication/CHAuthenticationProvider.java
@@ -81,6 +81,8 @@ public class CHAuthenticationProvider implements AuthenticationProvider {
             CHUserDetails userDetails;
             String affiliation = samlCredential.getAttributeAsString(SAML_ATTRIBUTE_AFFILIATION);
             switch (affiliation) {
+                case "pre-student":
+                    throw new CHPreStudentAuthenticatedException();
                 case "student":
                     String studentNumber = samlCredential.getAttributeAsString(SAML_ATTRIBUTE_STUDENTNUMBER);
                     String study = samlCredential.getAttributeAsString(SAML_ATTRIBUTE_DEPARTMENT);
@@ -91,11 +93,7 @@ public class CHAuthenticationProvider implements AuthenticationProvider {
                     break;
                 default:
                     log.warn("Unsupported SAML affiliation: affiliation={}", affiliation);
-                    if (affiliation.equals("pre-student")) {
-                        throw new CHPreStudentAuthenticatedException();
-                    } else {
-                        throw new CHInvalidMemberException();
-                    }
+                    throw new CHInvalidMemberException();
             }
 
             return CHAuthenticationToken.createAuthenticationToken(authentication, userDetails);

--- a/src/main/java/ch/wisv/connect/services/CHUserDetailsService.java
+++ b/src/main/java/ch/wisv/connect/services/CHUserDetailsService.java
@@ -270,6 +270,12 @@ public class CHUserDetailsService implements UserDetailsService {
         }
     }
 
+    public static class CHPreStudentAuthenticatedException extends CHAuthenticationException {
+        public CHPreStudentAuthenticatedException() {
+            super("Prospective student has authenticated, please wait until the academic year has started");
+        }
+    }
+
     public static class CHMemberConflictException extends CHAuthenticationException {
         public CHMemberConflictException() {
             super("Conflict between NetID and student number");

--- a/src/main/webapp/WEB-INF/user-context.xml
+++ b/src/main/webapp/WEB-INF/user-context.xml
@@ -53,6 +53,8 @@
             <map>
                 <entry key="ch.wisv.connect.services.CHUserDetailsService$CHInvalidMemberException"
                        value="/login?error=failure&amp;chMemberError=invalid"/>
+                <entry key="ch.wisv.connect.services.CHUserDetailsService$CHPreStudentAuthenticatedException"
+                       value="/login?error=failure&amp;chMemberError=pre-student"/>
                 <entry key="ch.wisv.connect.services.CHUserDetailsService$CHMemberConflictException"
                        value="/login?error=failure&amp;chMemberError=conflict"/>
             </map>

--- a/src/main/webapp/WEB-INF/views/login.jsp
+++ b/src/main/webapp/WEB-INF/views/login.jsp
@@ -293,12 +293,11 @@
                     and student number (if applicable).
                 </c:when>
                 <c:when test="${ param.chMemberError == 'pre-student'}">
-                    Your CH membership has been properly registered, however your student account is marked as "Pre-Student"
-                    indicating you account has not been fully enabled yet. Please wait until the academic year has started, 
-                    and then you should be able to login. If you are still not able to log-in while you believe you should, 
-                    please do not hesitate to <a href="https://ch.tudelft.nl/contact/">contact the board</a> so we can 
-                    correct your information in our membership administration. In your message, include your NetID and student 
-                    number (if applicable).<br>
+                    Your student account is marked as "Pre-Student" indicating you account has not been fully enabled yet.
+                    Please wait until the academic year has started, and then try again. If you are still not able to 
+                    log-in while you believe you should, please do not hesitate to <a href="https://ch.tudelft.nl/contact/">contact the board</a> 
+                    so we can correct your information in our membership administration. In your message, include your 
+                    NetID and student number (if applicable).<br>
                     Welcome to the TU Delft and hope to see you soon!
                 </c:when>
                 <c:otherwise>

--- a/src/main/webapp/WEB-INF/views/login.jsp
+++ b/src/main/webapp/WEB-INF/views/login.jsp
@@ -292,6 +292,15 @@
                     can correct your information in our membership administration. In your message, include your NetID
                     and student number (if applicable).
                 </c:when>
+                <c:when test="${ param.chMemberError == 'pre-student'}">
+                    Your CH membership has been properly registered, however your student account is marked as "Pre-Student"
+                    indicating you account has not been fully enabled yet. Please wait until the academic year has started, 
+                    and then you should be able to login. If you are still not able to log-in while you believe you should, 
+                    please do not hesitate to <a href="https://ch.tudelft.nl/contact/">contact the board</a> so we can 
+                    correct your information in our membership administration. In your message, include your NetID and student 
+                    number (if applicable).<br>
+                    Welcome to the TU Delft and hope to see you soon!
+                </c:when>
                 <c:otherwise>
                     <spring:message code="login.error"/>
                 </c:otherwise>


### PR DESCRIPTION
The SAML of the university login has a possible affiliation value of 'pre-student' We did not have proper error handling of this, making new members fear something with their membership went wrong.
Added a sensible message letting the user know that they should wait until the start of the academic year.